### PR TITLE
Add ReSample sampler

### DIFF
--- a/samplers/networks/base.py
+++ b/samplers/networks/base.py
@@ -11,7 +11,6 @@ C = TypeVar("C")
 
 
 class EpsilonNetwork(torch.nn.Module, ABC, Generic[C]):
-
     """Variance-preserving diffusion prior wrapper.
 
     Indexing contract (used by samplers and ``bridge_kernels``):
@@ -94,24 +93,22 @@ class LatentEpsilonNetwork(EpsilonNetwork[C], ABC, Generic[C]):
     def decode(self, z: Tensor, differentiable: bool = False):
         if not differentiable:
             with torch.no_grad():
-                out = self._decode(z=z)
+                out = self._decode(z=z, differentiable=False)
             return out.detach()
-        else:
-            return self._decode(z=z)
+        return self._decode(z=z, differentiable=True)
 
     @abstractmethod
-    def _decode(self, z: Tensor): ...
+    def _decode(self, z: Tensor, *, differentiable: bool = False): ...
 
     def encode(self, x: Tensor, differentiable: bool = False):
         if not differentiable:
             with torch.no_grad():
-                out = self._encode(x=x)
+                out = self._encode(x=x, differentiable=False)
             return out.detach()
-        else:
-            return self._encode(x=x)
+        return self._encode(x=x, differentiable=True)
 
     @abstractmethod
-    def _encode(self, x: Tensor): ...
+    def _encode(self, x: Tensor, *, differentiable: bool = False): ...
 
 
 @dataclasses.dataclass(slots=True)

--- a/samplers/networks/diffusers/stable_diffusion.py
+++ b/samplers/networks/diffusers/stable_diffusion.py
@@ -8,7 +8,6 @@ from diffusers.models.autoencoders.vae import DiagonalGaussianDistribution
 from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion import rescale_noise_cfg
 
 from samplers.dtypes import Device, DType, Shape
-
 from samplers.networks.base import LatentEpsilonNetwork
 
 
@@ -328,21 +327,22 @@ class StableDiffusionNetwork(LatentEpsilonNetwork[StableDiffusionCondition]):
 
         return noise_pred
 
-    @torch.inference_mode()
     def _decode(self, z: torch.Tensor, *, differentiable: bool = False) -> torch.Tensor:
         """Convert latent z → image x using the VAE decoder."""
         z_scaled = z / self._vae_latent_multiplier
-        with torch.set_grad_enabled(differentiable):
-            images = self.vae.decode(z_scaled, return_dict=False)[0]
-        return images
+        if differentiable:
+            return self.vae.decode(z_scaled, return_dict=False)[0]
+        with torch.inference_mode():
+            return self.vae.decode(z_scaled, return_dict=False)[0]
 
-    @torch.inference_mode()
     def _encode(self, x: torch.Tensor, *, differentiable: bool = False) -> torch.Tensor:
         """Convert image x → latent z using the VAE encoder (returns mean)."""
-        with torch.set_grad_enabled(differentiable):
+        if differentiable:
             distribution: DiagonalGaussianDistribution = self.vae.encode(x, return_dict=False)[0]
-            z_scaled = distribution.mean * self._vae_latent_multiplier
-        return z_scaled
+            return distribution.mean * self._vae_latent_multiplier
+        with torch.inference_mode():
+            distribution = self.vae.encode(x, return_dict=False)[0]
+            return distribution.mean * self._vae_latent_multiplier
 
     @property
     def device(self) -> torch.device:  # noqa: D401
@@ -369,4 +369,3 @@ class StableDiffusionNetwork(LatentEpsilonNetwork[StableDiffusionCondition]):
 
     def is_condition_initialized(self):
         return self._conditioning is not None
-

--- a/samplers/samplers/resample.py
+++ b/samplers/samplers/resample.py
@@ -1,0 +1,228 @@
+from typing import Generic, TypeVar
+
+import torch
+from torch import Tensor
+from tqdm import trange
+
+from samplers.dtypes import Shape
+from samplers.inverse_problem import InverseProblem
+from samplers.networks import LatentEpsilonNetwork
+from samplers.noise import GaussianNoise
+from samplers.samplers.base import PosteriorSampler
+from samplers.samplers.utils.batch_view import BatchView
+from samplers.samplers.utils.bridge_kernels import ddim_step_eps
+from samplers.samplers.utils.resample_kernels import (
+    alpha_broadcast,
+    compute_sigma,
+    dps_conditioning,
+    latent_optimization,
+    pixel_optimization,
+    stochastic_resample,
+)
+
+Condition_co = TypeVar("Condition_co", covariant=True)
+
+
+class ReSampleSampler(PosteriorSampler, Generic[Condition_co]):
+    """ReSample: latent diffusion inverse problems via hard data consistency [1].
+
+    Operates in latent space and requires a :class:`~samplers.networks.LatentEpsilonNetwork`.
+    Returns pixel-space reconstructions by default (``decode_output=True``), matching PSLD.
+
+    References
+    ----------
+    .. [1] Song, Bowen, et al. "Solving inverse problems with latent diffusion
+           models via hard data consistency." arXiv:2307.08123 (2023).
+    """
+
+    def __init__(self, network):
+        super().__init__(network)
+
+        if not isinstance(self._epsilon_network, LatentEpsilonNetwork):
+            raise TypeError(
+                f"{self.__class__.__name__} requires a latent diffusion model, "
+                f"but build_network returned a non-latent network "
+                f"({type(self._epsilon_network).__name__})."
+            )
+
+    def __call__(
+        self,
+        inverse_problem: InverseProblem,
+        *,
+        num_sampling_steps: int = 100,
+        num_reconstructions: int = 1,
+        scale: float = 0.3,
+        sigma_scale: float = 40.0,
+        max_optimization_iters: int = 2000,
+        eta: float = 1.0,
+        inter_timesteps: int = 5,
+        time_travel_interval: int = 10,
+        stage_splits: int = 3,
+        decode_output: bool = True,
+        condition: Condition_co | None = None,
+    ) -> Tensor:
+        """Run ReSample and return reconstructions.
+
+        Parameters
+        ----------
+        inverse_problem
+            Forward operator ``H``, observation ``y``, and noise model.
+        num_sampling_steps
+            Number of diffusion steps *T*.
+        num_reconstructions
+            Independent posterior samples per observation.
+        scale
+            Base DPS step size (combined dynamically with ``alphas_cumprod``).
+        sigma_scale
+            Scales stochastic resample variance.
+        max_optimization_iters
+            Max AdamW iterations for pixel/latent consistency optimization.
+        eta
+            DDIM stochasticity (0 = deterministic, 1 = DDPM-like).
+        inter_timesteps
+            Extra denoising steps during time-travel blocks.
+        time_travel_interval
+            Run a time-travel block every this many loop indices.
+        stage_splits
+            Split reverse trajectory into pixel- vs latent-optimization stages.
+        decode_output
+            If *True*, decode final latents to pixel space before returning.
+        condition
+            Optional conditioning passed through to ``epsilon_network``.
+        """
+        x_shape: Shape = inverse_problem.operator.x_shape
+        batch_shape: Shape = inverse_problem.batch_shape
+
+        x_view = BatchView(batch_shape, num_reconstructions, x_shape)
+
+        epsilon_net: LatentEpsilonNetwork = self._epsilon_network
+        latent_shape: Shape = epsilon_net.get_latent_shape(x_shape)
+        z_view = BatchView(batch_shape, num_reconstructions, latent_shape)
+
+        flat_batch_size = z_view.leading_size
+        spatial_ndim = len(latent_shape) + 1  # batch + latent dims
+
+        epsilon_net.set_sampling_parameters(
+            num_sampling_steps=num_sampling_steps,
+            num_reconstructions=num_reconstructions,
+            batch_size=x_view.batch_size,
+        )
+        epsilon_net.set_condition(condition)
+
+        try:
+            z_t: Tensor = torch.randn(
+                z_view.flat_shape,
+                device=epsilon_net.device,
+                dtype=epsilon_net.dtype,
+            ).requires_grad_()
+
+            timesteps = epsilon_net.timesteps
+            observation_flat = x_view.repeat_observation(inverse_problem.observation)
+            operator = inverse_problem.operator
+
+            if isinstance(inverse_problem.noise, GaussianNoise):
+                eps = float(inverse_problem.noise.sigma.item())
+            else:
+                eps = 1e-3
+
+            total_steps = len(timesteps) - 1
+            index_split = total_steps // stage_splits
+
+            for idx in trange(len(timesteps) - 1, 1, -1):
+                timestep = int(timesteps[idx])
+                timestep_prev = int(timesteps[idx - 1])
+
+                z_t = z_t.detach().requires_grad_()
+
+                z_next, _z0_pred, pseudo_z0 = ddim_step_eps(
+                    z_t,
+                    epsilon_net=epsilon_net,
+                    t=timestep,
+                    t_prev=timestep_prev,
+                    eta=eta,
+                )
+
+                a_t = alpha_broadcast(
+                    epsilon_net, timestep, batch_size=flat_batch_size, spatial_ndim=spatial_ndim
+                )
+                dps_scale = a_t * 0.5
+
+                z_t = dps_conditioning(
+                    z_t,
+                    z_next,
+                    pseudo_z0,
+                    observation_flat,
+                    operator=operator,
+                    epsilon_net=epsilon_net,
+                    scale=dps_scale,
+                )
+
+                if (
+                    idx <= (total_steps - index_split)
+                    and idx > 0
+                    and idx % time_travel_interval == 0
+                ):
+                    x_t_snapshot = z_t.detach().clone()
+
+                    for k in range(idx, max(idx - inter_timesteps, 1), -1):
+                        if k <= 1:
+                            break
+                        t_k = int(timesteps[k])
+                        t_prev_k = int(timesteps[k - 1])
+                        z_t, _z0_k, pseudo_z0 = ddim_step_eps(
+                            z_t,
+                            epsilon_net=epsilon_net,
+                            t=t_k,
+                            t_prev=t_prev_k,
+                            eta=eta,
+                        )
+
+                    a_prev = alpha_broadcast(
+                        epsilon_net,
+                        timestep_prev,
+                        batch_size=flat_batch_size,
+                        spatial_ndim=spatial_ndim,
+                    )
+                    sigma = compute_sigma(sigma_scale, a_t, a_prev)
+
+                    if idx >= index_split:
+                        pseudo_z0 = pseudo_z0.detach()
+                        x_pixel = epsilon_net.decode(pseudo_z0, differentiable=False)
+                        x_opt = pixel_optimization(
+                            observation_flat,
+                            x_pixel,
+                            operator=operator,
+                            eps=eps,
+                            max_iters=max_optimization_iters,
+                        )
+                        z_opt = epsilon_net.encode(x_opt, differentiable=False)
+                        z_t = stochastic_resample(z_opt, x_t_snapshot, a_prev, sigma)
+                        z_t = z_t.requires_grad_()
+                    else:
+                        z_opt = latent_optimization(
+                            observation_flat,
+                            pseudo_z0.detach(),
+                            operator=operator,
+                            epsilon_net=epsilon_net,
+                            eps=eps,
+                            max_iters=max_optimization_iters,
+                        )
+                        z_t = stochastic_resample(z_opt, x_t_snapshot, a_prev, sigma)
+
+            final_z0 = latent_optimization(
+                observation_flat,
+                z_t.detach(),
+                operator=operator,
+                epsilon_net=epsilon_net,
+                eps=eps,
+                max_iters=max_optimization_iters,
+            )
+
+            if decode_output:
+                x0_output = epsilon_net.decode(final_z0, differentiable=False)
+                return x_view.unflatten(x0_output)
+
+            return z_view.unflatten(final_z0)
+        finally:
+            epsilon_net.clear_condition()
+            epsilon_net.clear_sampling_parameters()

--- a/samplers/samplers/utils/bridge_kernels.py
+++ b/samplers/samplers/utils/bridge_kernels.py
@@ -73,3 +73,43 @@ def ddim_step(
     return sample_bridge_kernel(
         x_ell=x, x_s=e_t, epsilon_net=epsilon_net, ell=t, t=t_prev, s=t_0, eta=eta
     )
+
+
+def _broadcast_schedule_coeff(coeff: Tensor, x: Tensor) -> Tensor:
+    return coeff.to(device=x.device, dtype=x.dtype).view(-1, *([1] * (x.ndim - 1)))
+
+
+def ddim_step_eps(
+    x: Tensor,
+    *,
+    epsilon_net: EpsilonNetwork,
+    t: int,
+    t_prev: int,
+    eta: float,
+) -> tuple[Tensor, Tensor, Tensor]:
+    """DDIM update in epsilon parameterization (returns ``x_prev``, ``x0``,
+    pseudo-``x0``).
+
+    Used by ReSample; DPS/PGDM use :func:`ddim_step` (x₀ bridge formulation).
+    """
+    acp_t = epsilon_net.alphas_cumprod[t]
+    acp_prev = epsilon_net.alphas_cumprod[t_prev]
+
+    with torch.no_grad():
+        e_t = epsilon_net.predict_noise(x, t)
+
+    sqrt_oma_t = (1 - acp_t).sqrt()
+    a_t = _broadcast_schedule_coeff(acp_t, x)
+    a_prev = _broadcast_schedule_coeff(acp_prev, x)
+    sqrt_oma = _broadcast_schedule_coeff(sqrt_oma_t, x)
+
+    pred_x0 = (x - sqrt_oma * e_t) / a_t.sqrt()
+    pseudo_x0 = (x - (1 - acp_t) * e_t) / a_t.sqrt()
+
+    sigma_t = eta * ((1 - acp_prev) / (1 - acp_t) * (1 - acp_t / acp_prev)).clamp(min=0).sqrt()
+    sigma = _broadcast_schedule_coeff(sigma_t, x)
+    dir_xt = (1 - acp_prev - sigma_t**2).clamp(min=0).sqrt() * e_t
+    noise = sigma * torch.randn_like(x)
+    x_prev = a_prev.sqrt() * pred_x0 + dir_xt + noise
+
+    return x_prev, pred_x0, pseudo_x0

--- a/samplers/samplers/utils/resample_kernels.py
+++ b/samplers/samplers/utils/resample_kernels.py
@@ -1,0 +1,129 @@
+"""ReSample-only helpers (hard consistency optimization, stochastic resample).
+
+Shared diffusion math lives in :mod:`bridge_kernels` (``ddim_step_eps``).
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import Tensor
+
+from samplers.networks.base import EpsilonNetwork, LatentEpsilonNetwork
+from samplers.operators.base import Operator
+
+
+def dps_conditioning(
+    z_leaf: Tensor,
+    x_t: Tensor,
+    x_0_hat: Tensor,
+    measurement: Tensor,
+    *,
+    operator: Operator,
+    epsilon_net: LatentEpsilonNetwork,
+    scale: Tensor | float,
+) -> Tensor:
+    """Posterior-sampling gradient step on ``x_t`` (ReSample DPS hook)."""
+    difference = measurement - operator.apply(epsilon_net.decode(x_0_hat, differentiable=True))
+    norm = torch.linalg.norm(difference)
+    norm_grad = torch.autograd.grad(outputs=norm, inputs=z_leaf)[0]
+    return x_t - norm_grad * scale
+
+
+def pixel_optimization(
+    measurement: Tensor,
+    x_prime: Tensor,
+    *,
+    operator: Operator,
+    eps: float,
+    max_iters: int,
+) -> Tensor:
+    """Argmin :math:`\\|y - A(x)\\|_2^2` in pixel space."""
+    loss_fn = torch.nn.MSELoss()
+    opt_var = x_prime.detach().clone().requires_grad_()
+    optimizer = torch.optim.AdamW([opt_var], lr=1e-2)
+    measurement = measurement.detach()
+
+    for _ in range(max_iters):
+        optimizer.zero_grad()
+        measurement_loss = loss_fn(measurement, operator.apply(opt_var))
+        measurement_loss.backward()
+        optimizer.step()
+        if measurement_loss.item() < eps**2:
+            break
+
+    return opt_var.detach()
+
+
+def latent_optimization(
+    measurement: Tensor,
+    z_init: Tensor,
+    *,
+    operator: Operator,
+    epsilon_net: LatentEpsilonNetwork,
+    eps: float,
+    max_iters: int,
+) -> Tensor:
+    """Argmin :math:`\\|y - A(D(z))\\|_2^2` in latent space."""
+    if not z_init.requires_grad:
+        z_init = z_init.requires_grad_()
+
+    loss_fn = torch.nn.MSELoss()
+    optimizer = torch.optim.AdamW([z_init], lr=5e-3)
+    measurement = measurement.detach()
+    losses: list[float] = []
+
+    for itr in range(max_iters):
+        optimizer.zero_grad()
+        decoded = epsilon_net.decode(z_init, differentiable=True)
+        output = loss_fn(measurement, operator.apply(decoded))
+        output.backward()
+        optimizer.step()
+        cur_loss = output.detach().item()
+
+        if itr >= 200:
+            losses.append(cur_loss)
+            if len(losses) > 1 and losses[0] < cur_loss:
+                break
+            if len(losses) > 1:
+                losses.pop(0)
+
+        if cur_loss < eps**2:
+            break
+
+    return z_init.detach()
+
+
+def stochastic_resample(
+    pseudo_x0: Tensor,
+    x_t: Tensor,
+    a_t: Tensor,
+    sigma: Tensor,
+) -> Tensor:
+    """Stochastic resample step from the ReSample paper."""
+    device = pseudo_x0.device
+    noise = torch.randn_like(pseudo_x0, device=device)
+    return (sigma * a_t.sqrt() * pseudo_x0 + (1 - a_t) * x_t) / (
+        sigma + 1 - a_t
+    ) + noise * torch.sqrt(1 / (1 / sigma + 1 / (1 - a_t)))
+
+
+def alpha_broadcast(
+    epsilon_net: EpsilonNetwork,
+    t: int,
+    *,
+    batch_size: int,
+    spatial_ndim: int,
+) -> Tensor:
+    """Return ``alphas_cumprod[t]`` shaped ``(batch_size, 1, …, 1)``."""
+    acp = epsilon_net.alphas_cumprod[t].to(device=epsilon_net.device, dtype=epsilon_net.dtype)
+    shape = (batch_size,) + (1,) * (spatial_ndim - 1)
+    return acp.expand(shape)
+
+
+def compute_sigma(
+    sigma_scale: float,
+    a_t: Tensor,
+    a_prev: Tensor,
+) -> Tensor:
+    """Variance schedule for stochastic resample."""
+    return sigma_scale * (1 - a_prev) / (1 - a_t) * (1 - a_t / a_prev)

--- a/scripts/run_resample.py
+++ b/scripts/run_resample.py
@@ -1,0 +1,116 @@
+"""Run ReSample on SD 1.5 for a noisy identity inverse problem.
+
+Defaults match mgdm ``configs/experiments/sampler/resample.yaml``:
+  nsteps=500, max_optimization_iters=200, sigma_scale=40, obs std=0.05
+
+Usage:
+  PYTHONPATH=. python scripts/run_resample.py
+  PYTHONPATH=. python scripts/run_resample.py --quick   # 50 steps, faster smoke
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import torch
+from PIL import Image
+
+from samplers.config import MODELS_DIRECTORY
+from samplers.inverse_problem import InverseProblem
+from samplers.networks import StableDiffusionCondition, StableDiffusionNetwork
+from samplers.noise import GaussianNoise
+from samplers.operators import IdentityOperator
+from samplers.samplers.resample import ReSampleSampler
+from samplers.utils.image import pil_to_tensor, tensor_to_pil
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+def psnr(x: torch.Tensor, y: torch.Tensor) -> float:
+    mse = (x - y).pow(2).mean().item()
+    if mse == 0:
+        return float("inf")
+    return 10.0 * torch.log10(torch.tensor(4.0 / mse)).item()
+
+
+def load_image(path: Path, size: int, *, dtype: torch.dtype, device: str) -> torch.Tensor:
+    image = Image.open(path).convert("RGB")
+    if size and (image.width != size or image.height != size):
+        image = image.resize((size, size), Image.Resampling.LANCZOS)
+    return pil_to_tensor(image, dtype=dtype, device=device)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="ReSample + SD1.5 identity denoising demo")
+    parser.add_argument("--image", type=Path, default=SCRIPT_DIR / "ddpm.png")
+    parser.add_argument("--size", type=int, default=512, help="SD1.5 native resolution")
+    parser.add_argument("--sigma", type=float, default=0.05, help="Observation noise (mgdm std)")
+    parser.add_argument("--steps", type=int, default=None, help="Diffusion steps (default 500)")
+    parser.add_argument("--opt-iters", type=int, default=None, help="AdamW iters (default 200)")
+    parser.add_argument(
+        "--quick", action="store_true", help="50 steps / 50 opt iters for a fast check"
+    )
+    args = parser.parse_args()
+
+    if args.quick:
+        num_steps = args.steps or 50
+        max_opt = args.opt_iters or 50
+    else:
+        num_steps = args.steps or 500
+        max_opt = args.opt_iters or 200
+
+    dtype = torch.float32
+    device = "cuda:0"
+
+    print(
+        f"ReSample demo: steps={num_steps}, opt_iters={max_opt}, sigma={args.sigma}, size={args.size}"
+    )
+
+    model_id = "sd-legacy/stable-diffusion-v1-5"
+    network = StableDiffusionNetwork.from_pretrained(
+        model_id, torch_dtype=dtype, cache_dir=MODELS_DIRECTORY, device=device
+    )
+
+    x_true = load_image(args.image, args.size, dtype=dtype, device=device)
+    x_shape = x_true.shape
+
+    operator = IdentityOperator(x_shape=x_shape)
+    noise = GaussianNoise(sigma=args.sigma, device=device, dtype=dtype)
+
+    inverse_problem = InverseProblem.from_clean_data(
+        x_true=x_true,
+        noise=noise,
+        operator=operator,
+    )
+
+    condition = StableDiffusionCondition(prompt="", guidance_scale=1.0)
+
+    sampler = ReSampleSampler(network=network)
+    x_hat = sampler(
+        inverse_problem=inverse_problem,
+        num_sampling_steps=num_steps,
+        num_reconstructions=1,
+        max_optimization_iters=max_opt,
+        sigma_scale=40.0,
+        eta=1.0,
+        condition=condition,
+    )
+    x_hat = x_hat[0]
+
+    x_obs = inverse_problem.observation
+
+    ref_pil = tensor_to_pil(x_true)
+    obs_pil = tensor_to_pil(x_obs)
+    rec_pil = tensor_to_pil(x_hat)
+
+    ref_pil.save(SCRIPT_DIR / "resample_reference.png")
+    obs_pil.save(SCRIPT_DIR / "resample_observation.png")
+    rec_pil.save(SCRIPT_DIR / "resample_reconstruction.png")
+
+    psnr_ref = psnr(x_hat.detach().float(), x_true.float())
+    psnr_obs = psnr(x_hat.detach().float(), x_obs.float())
+    print(f"PSNR(reconstruction, reference): {psnr_ref:.2f} dB")
+    print(f"PSNR(reconstruction, observation): {psnr_obs:.2f} dB")
+    print(f"PSNR(observation, reference): {psnr(x_obs.float(), x_true.float()):.2f} dB")
+    print(f"Saved outputs to {SCRIPT_DIR}/resample_*.png")

--- a/tests/samplers/test_resample.py
+++ b/tests/samplers/test_resample.py
@@ -1,0 +1,197 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+import torch
+
+from samplers.inverse_problem import InverseProblem
+from samplers.noise import GaussianNoise
+from samplers.operators.identity import IdentityOperator
+
+_root = Path(__file__).resolve().parents[2]
+
+
+def _load_module(relative: str, name: str):
+    path = _root / relative
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_base = _load_module("samplers/networks/base.py", "networks_base")
+EpsilonNetwork = _base.EpsilonNetwork
+LatentEpsilonNetwork = _base.LatentEpsilonNetwork
+NoCondition = _base.NoCondition
+
+_networks_pkg = types.ModuleType("samplers.networks")
+_networks_pkg.__path__ = [str(_root / "samplers" / "networks")]
+_networks_pkg.EpsilonNetwork = EpsilonNetwork
+_networks_pkg.LatentEpsilonNetwork = LatentEpsilonNetwork
+_networks_pkg.base = _base
+sys.modules["samplers.networks"] = _networks_pkg
+sys.modules["samplers.networks.base"] = _base
+
+_sampler_base = _load_module("samplers/samplers/base.py", "sampler_base")
+_samplers_pkg = types.ModuleType("samplers.samplers")
+_samplers_pkg.__path__ = [str(_root / "samplers" / "samplers")]
+_samplers_pkg.PosteriorSampler = _sampler_base.PosteriorSampler
+_samplers_pkg.base = _sampler_base
+sys.modules["samplers.samplers"] = _samplers_pkg
+sys.modules["samplers.samplers.base"] = _sampler_base
+
+_utils_pkg = types.ModuleType("samplers.samplers.utils")
+_utils_pkg.__path__ = [str(_root / "samplers" / "samplers" / "utils")]
+_batch_view = _load_module("samplers/samplers/utils/batch_view.py", "batch_view")
+_bridge = _load_module("samplers/samplers/utils/bridge_kernels.py", "bridge_kernels")
+_resample_kernels = _load_module("samplers/samplers/utils/resample_kernels.py", "resample_kernels")
+_utils_pkg.batch_view = _batch_view
+_utils_pkg.bridge_kernels = _bridge
+_utils_pkg.resample_kernels = _resample_kernels
+sys.modules["samplers.samplers.utils"] = _utils_pkg
+sys.modules["samplers.samplers.utils.batch_view"] = _batch_view
+sys.modules["samplers.samplers.utils.bridge_kernels"] = _bridge
+sys.modules["samplers.samplers.utils.resample_kernels"] = _resample_kernels
+
+_resample = _load_module("samplers/samplers/resample.py", "resample")
+ReSampleSampler = _resample.ReSampleSampler
+
+
+class MockLatentEpsilonNetwork(LatentEpsilonNetwork[NoCondition]):
+    """Minimal latent VP network with identity encode/decode."""
+
+    def __init__(self, num_steps: int = 5) -> None:
+        alphas = torch.linspace(0.99, 0.5, num_steps)
+        alphas_cumprod = torch.cat([torch.tensor([1.0]), alphas])
+        super().__init__(alphas_cumprod=alphas_cumprod)
+        self._num_steps = num_steps
+
+    def forward(self, x: torch.Tensor, t: torch.Tensor | int) -> torch.Tensor:
+        return torch.zeros_like(x)
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        raise NotImplementedError
+
+    def get_latent_shape(self, x_shape: tuple[int, ...]) -> tuple[int, ...]:
+        return x_shape
+
+    def _encode(self, x: torch.Tensor, *, differentiable: bool = False) -> torch.Tensor:
+        return x
+
+    def _decode(self, z: torch.Tensor, *, differentiable: bool = False) -> torch.Tensor:
+        return z
+
+    def set_sampling_parameters(
+        self,
+        num_sampling_steps: int,
+        batch_size: int = 1,
+        num_reconstructions: int = 1,
+    ) -> None:
+        self._batch_size = batch_size
+        self._num_sampling_steps = num_sampling_steps
+        self._num_reconstructions = num_reconstructions
+        timesteps = torch.arange(1, num_sampling_steps + 1, dtype=torch.long)
+        self.register_buffer("timesteps", timesteps, persistent=True)
+
+    @property
+    def is_condition_initialized(self) -> bool:
+        return True
+
+    def set_condition(self, condition: NoCondition | None = None) -> None:
+        pass
+
+    def clear_condition(self) -> None:
+        pass
+
+
+class PlainEpsilonNetwork(EpsilonNetwork[NoCondition]):
+    def __init__(self) -> None:
+        super().__init__(alphas_cumprod=torch.tensor([1.0, 0.9]))
+
+    def forward(self, x: torch.Tensor, t: torch.Tensor | int) -> torch.Tensor:
+        return torch.zeros_like(x)
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        raise NotImplementedError
+
+    def set_sampling_parameters(self, num_sampling_steps: int, batch_size: int = 1, **_) -> None:
+        self.register_buffer("timesteps", torch.arange(1, num_sampling_steps + 1), persistent=True)
+
+    @property
+    def is_condition_initialized(self) -> bool:
+        return True
+
+    def set_condition(self, condition: NoCondition | None = None) -> None:
+        pass
+
+    def clear_condition(self) -> None:
+        pass
+
+
+def _make_problem(*, batch_shape: tuple[int, ...], x_shape: tuple[int, ...]) -> InverseProblem:
+    operator = IdentityOperator(x_shape=x_shape)
+    observation = torch.randn(*batch_shape, *x_shape)
+    noise = GaussianNoise(sigma=0.01)
+    return InverseProblem(operator=operator, observation=observation, noise=noise)
+
+
+def _fast_kwargs(**overrides):
+    defaults = dict(
+        num_sampling_steps=5,
+        max_optimization_iters=5,
+        time_travel_interval=100,
+    )
+    defaults.update(overrides)
+    return defaults
+
+
+def test_resample_smoke_single_batch():
+    x_shape = (2, 4)
+    problem = _make_problem(batch_shape=(), x_shape=x_shape)
+    sampler = ReSampleSampler(MockLatentEpsilonNetwork(num_steps=5))
+
+    out = sampler(problem, num_reconstructions=1, **_fast_kwargs())
+
+    assert out.shape == (1, *x_shape)
+
+
+def test_resample_batched_observations():
+    x_shape = (2, 4)
+    problem = _make_problem(batch_shape=(2,), x_shape=x_shape)
+    sampler = ReSampleSampler(MockLatentEpsilonNetwork(num_steps=5))
+
+    out = sampler(problem, num_reconstructions=2, **_fast_kwargs())
+
+    assert out.shape == (2, 2, *x_shape)
+
+
+def test_resample_decode_output_false():
+    x_shape = (2, 4)
+    problem = _make_problem(batch_shape=(), x_shape=x_shape)
+    sampler = ReSampleSampler(MockLatentEpsilonNetwork(num_steps=5))
+
+    out = sampler(problem, decode_output=False, **_fast_kwargs())
+
+    assert out.shape == (1, *x_shape)
+
+
+def test_resample_requires_latent_network():
+    with pytest.raises(TypeError, match="latent diffusion model"):
+        ReSampleSampler(PlainEpsilonNetwork())
+
+
+def test_stochastic_resample_shape():
+    b, c, h, w = 2, 3, 4, 4
+    pseudo_x0 = torch.randn(b, c, h, w)
+    x_t = torch.randn(b, c, h, w)
+    a_t = torch.full((b, 1, 1, 1), 0.8)
+    sigma = torch.full((b, 1, 1, 1), 0.5)
+
+    out = _resample_kernels.stochastic_resample(pseudo_x0, x_t, a_t, sigma)
+
+    assert out.shape == pseudo_x0.shape


### PR DESCRIPTION
## Summary
- Add **ReSample** latent-space posterior sampler (Song et al., hard data consistency)
- Fix **differentiable VAE encode/decode** on `StableDiffusionNetwork` (required for latent optimization)
- Pass `differentiable` through `LatentEpsilonNetwork` encode/decode to adapters
- Add `ddim_step_eps` to shared `bridge_kernels` (epsilon DDIM); ReSample-only helpers stay in `resample_kernels`
- Experimental: **not** exported in `__all__` until integration tests pass

## Changes
| Area | Files |
|------|-------|
| ReSample | `samplers/samplers/resample.py`, `samplers/samplers/utils/resample_kernels.py` |
| Shared DDIM | `samplers/samplers/utils/bridge_kernels.py` (`ddim_step_eps`) |
| Networks | `samplers/networks/base.py`, `samplers/networks/diffusers/stable_diffusion.py` |
| Tests | `tests/samplers/test_resample.py` |
| Script | `scripts/run_resample.py` |

## Design notes
- **Reuse now:** `ddim_step_eps` lives alongside `ddim_step` in `bridge_kernels` (x₀ bridge vs ε formulation).
- **ReSample-only for now:** pixel/latent AdamW optimization, stochastic resample, DPS conditioning hook — no shared abstraction yet; could move to a generic `consistency_kernels` module if PSLD/MGDM converge on similar patterns.
- **Future:** export in `__all__`, SD integration test in CI, optional `docs/CONTEXT.md` glossary update (separate MR).

## Test plan
- [x] pytest tests/samplers/test_resample.py
- [x] pytest tests/samplers/ (10 passed)
- [ ] python scripts/run_resample.py --quick (manual, GPU)
- [ ] python scripts/run_resample.py (500 steps, manual, GPU)